### PR TITLE
docs: add component pkgsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Go Component SDK
 
+[![Go Reference](https://pkg.go.dev/badge/go.wasmcloud.dev/component.svg)](https://pkg.go.dev/go.wasmcloud.dev/component)
+
 Warning: API stabilization in progress. Once ready it will be published as `v0.0.1`.
 
 The Go Component SDK provides a set of packages to simplify the development of WebAssembly components targeting the [wasmCloud](https://wasmcloud.com) host runtime.


### PR DESCRIPTION
Created badge with:
https://pkg.go.dev/badge/?path=https%3A%2F%2Fpkg.go.dev%2Fgo.wasmcloud.dev%2Fcomponent

I verified the link is working using the vanity: https://pkg.go.dev/go.wasmcloud.dev/component