### PR TITLE
chore: Release 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Requires tinygo 0.33 or above.
 Import `go.wasmcloud.dev/component` in your Go module.
 
 ```bash
-go get go.wasmcloud.dev/component@v0.0.3
+go get go.wasmcloud.dev/component@v0.0.4
 ```
 
 Import the SDK WIT. In `wit/deps.toml`:
 
 ```toml
 
-wasmcloud-component = "https://github.com/wasmCloud/component-sdk-go/archive/v0.0.3.tar.gz"
+wasmcloud-component = "https://github.com/wasmCloud/component-sdk-go/archive/v0.0.4.tar.gz"
 
 ```
 

--- a/_examples/http-client/go.mod
+++ b/_examples/http-client/go.mod
@@ -4,7 +4,7 @@ go 1.23.0
 
 require (
 	github.com/bytecodealliance/wasm-tools-go v0.3.1
-	go.wasmcloud.dev/component v0.0.3
+	go.wasmcloud.dev/component v0.0.4
 )
 
 require (

--- a/_examples/http-server/go.mod
+++ b/_examples/http-server/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/bytecodealliance/wasm-tools-go v0.3.1
 	github.com/stretchr/testify v1.9.0
-	go.wasmcloud.dev/component v0.0.3
+	go.wasmcloud.dev/component v0.0.4
 	go.wasmcloud.dev/wadge v0.7.0
 )
 

--- a/_examples/invoke/go.mod
+++ b/_examples/invoke/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 require (
 	github.com/bytecodealliance/wasm-tools-go v0.3.1
 	github.com/stretchr/testify v1.9.0
-	go.wasmcloud.dev/component v0.0.3
+	go.wasmcloud.dev/component v0.0.4
 	go.wasmcloud.dev/wadge v0.7.0
 )
 


### PR DESCRIPTION
## Changelog preview
* chore: add MAINTAINERS.md by @brooksmtownsend in https://github.com/wasmCloud/component-sdk-go/pull/26
* chore: update `wadge` by @rvolosatovs in https://github.com/wasmCloud/component-sdk-go/pull/27
* chore(examples): Include invoke example in CI by @joonas in https://github.com/wasmCloud/component-sdk-go/pull/28
* chore(examples): Use the published go.wasmcloud.dev/component module by @joonas in https://github.com/wasmCloud/component-sdk-go/pull/29
* chore: Regenerate bindings with wit-bindgen-go 0.3.0 by @lxfontes in https://github.com/wasmCloud/component-sdk-go/pull/30
* chore: update `wadge` by @rvolosatovs in https://github.com/wasmCloud/component-sdk-go/pull/31
* chore(deps): Bump softprops/action-gh-release from 2.0.8 to 2.0.9 by @dependabot in https://github.com/wasmCloud/component-sdk-go/pull/32
* chore(deps): Bump github.com/bytecodealliance/wasm-tools-go from 0.3.0 to 0.3.1 by @dependabot in https://github.com/wasmCloud/component-sdk-go/pull/33
* chore: Matrix Testing Tinygo Versions by @lxfontes in https://github.com/wasmCloud/component-sdk-go/pull/34
