### PR TITLE
chore: grant `golangci-lint-action` the permission to create annotations

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -12,6 +12,12 @@ env:
 
 jobs:
   lint:
+    # Context: https://github.com/golangci/golangci-lint-action/blob/v6.1.1/README.md#annotations
+    permissions:
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Optional: allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +56,12 @@ jobs:
         run: go test -v ./...
 
   examples:
+    # Context: https://github.com/golangci/golangci-lint-action/blob/v6.1.1/README.md#annotations
+    permissions:
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Optional: allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
     strategy:
       matrix:
         example:
@@ -91,4 +103,5 @@ jobs:
 
       - name: wash build
         working-directory: "_examples/${{ matrix.example }}"
-        run: wash build
+        run: |
+          wash build


### PR DESCRIPTION
## Feature or Problem

Adds the necessary permissions for `golangci-lint-action` to be able to [create annotations](https://github.com/golangci/golangci-lint-action/blob/v6.1.1/README.md#annotations)

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
